### PR TITLE
Не строгий парсинг dotenv

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -6,4 +6,6 @@ from src.config_schema import Settings
 # settings_path = os.getenv("SETTINGS_PATH", "settings.yaml")
 # settings: Settings = Settings.from_yaml(Path(settings_path)) if Path(settings_path).exists() else Settings() # type: ignore
 
-settings = Settings.from_env(Path(".env"))
+
+settings_path = os.getenv("SETTINGS_PATH", ".env")
+settings: Settings = Settings.from_env(Path(settings_path)) if Path(settings_path).exists() else Settings() # type: ignore

--- a/backend/src/config_schema.py
+++ b/backend/src/config_schema.py
@@ -17,7 +17,7 @@ class Environment(StrEnum):
 
 
 class SettingBaseModel(BaseModel):
-    model_config = ConfigDict(use_attribute_docstrings=True, extra="forbid")
+    model_config = ConfigDict(use_attribute_docstrings=True, extra="ignore")
 
 
 class Settings(SettingBaseModel):


### PR DESCRIPTION
Вместо того, чтобы завершать с ошибкой, когда перменных больше чем нужно, они просто игнорируются